### PR TITLE
Fixed a warning in UNITTEST macro

### DIFF
--- a/unit.hpp
+++ b/unit.hpp
@@ -45,20 +45,54 @@ int main() {
 #include <type_traits>
 #include <limits>
 
-#ifdef SWEET_NO_UNITTEST
-#define UNITTEST(test_name,...) \
+#define PP_HAS_ARGS_IMPL2(_1, _2, _3, N, ...) N
+#define PP_HAS_ARGS_SOURCE() MULTI, MULTI, ONE, ERROR
+#define PP_HAS_ARGS_IMPL(...) PP_HAS_ARGS_IMPL2(__VA_ARGS__)
+#define PP_HAS_ARGS(...)      PP_HAS_ARGS_IMPL(__VA_ARGS__, PP_HAS_ARGS_SOURCE())
+
+
+#define __UTEST_NOTEST_ONE(test_name) \
 class test_name##_test_class : public Unit::Unittest { void nevercall(); \
 public: \
-test_name##_test_class() : Unit::Unittest(#test_name,__FILE__,__LINE__,##__VA_ARGS__) {} \
+test_name##_test_class() : Unit::Unittest(#test_name,__FILE__,__LINE__) {} \
 } test_name##_test_class_impl; \
 void test_name##_test_class::nevercall()
-#else
-#define UNITTEST(test_name,...) \
+
+#define __UTEST_NOTEST_MULTI(test_name,...) \
+class test_name##_test_class : public Unit::Unittest { void nevercall(); \
+public: \
+test_name##_test_class() : Unit::Unittest(#test_name,__FILE__,__LINE__,__VA_ARGS__) {} \
+} test_name##_test_class_impl; \
+void test_name##_test_class::nevercall()
+
+#define __UTEST_NOTEST_DISAMBIGUATE2(has_args, ...) __UTEST_NOTEST_ ## has_args (__VA_ARGS__)
+#define __UTEST_NOTEST_DISAMBIGUATE(has_args, ...) __UTEST_NOTEST_DISAMBIGUATE2(has_args, __VA_ARGS__)
+#define __UTEST_NOTEST(...) __UTEST_NOTEST_DISAMBIGUATE(PP_HAS_ARGS(__VA_ARGS__), __VA_ARGS__)
+
+
+#define __UTEST_ONE(test_name) \
 class test_name##_test_class : public Unit::Unittest { void run_impl(); \
 public: \
-test_name##_test_class() : Unit::Unittest(#test_name,__FILE__,__LINE__,##__VA_ARGS__) {} \
+test_name##_test_class() : Unit::Unittest(#test_name,__FILE__,__LINE__) {} \
 } test_name##_test_class_impl; \
 void test_name##_test_class::run_impl()
+
+#define __UTEST_MULTI(test_name,...) \
+class test_name##_test_class : public Unit::Unittest { void run_impl(); \
+public: \
+test_name##_test_class() : Unit::Unittest(#test_name,__FILE__,__LINE__,__VA_ARGS__) {} \
+} test_name##_test_class_impl; \
+void test_name##_test_class::run_impl()
+
+#define __UTEST_DISAMBIGUATE2(has_args, ...) __UTEST_ ## has_args (__VA_ARGS__)
+#define __UTEST_DISAMBIGUATE(has_args, ...) __UTEST_DISAMBIGUATE2(has_args, __VA_ARGS__)
+#define __UTEST(...) __UTEST_DISAMBIGUATE(PP_HAS_ARGS(__VA_ARGS__), __VA_ARGS__)
+
+
+#ifdef SWEET_NO_UNITTEST
+#define UNITTEST(...) __UTEST_NOTEST(__VA_ARGS__)
+#else
+#define UNITTEST(...) __UTEST(__VA_ARGS__)
 #endif
 
 #define AS_EQ(e1,e2)				UNIT_COMPARE(true,true,e1,e2,"")


### PR DESCRIPTION
This is a work-around which fixes the standard violation I described in issue https://github.com/burner/sweet.hpp/issues/2. It follows the following pattern:

http://stackoverflow.com/questions/5355241/generating-function-declaration-using-a-macro-iteration/5355946#5355946

In its current form it generates correct code for 1-3 arguments. If you like to add more arguments to the `Unit::Unittest`-Constructor this will not be sufficient and the following lines has to be changed:

```
#define PP_HAS_ARGS_IMPL2(_1, _2, _3, N, ...) N
#define PP_HAS_ARGS_SOURCE() MULTI, MULTI, ONE, ERROR
```

i.e. add an argument to `PP_HAS_ARGS_IMPL2` and a `MULTI,` to `PP_HAS_ARGS_SOURCE`

e.g. 4 arguments would be:

```
#define PP_HAS_ARGS_IMPL2(_1, _2, _3, _4, N, ...) N
#define PP_HAS_ARGS_SOURCE() MULTI, MULTI, MULTI, ONE, ERROR
```

I know it looks scary but until `##__VA_ARGS__` gets standardized it is the only warning-free option
