### PR TITLE
bugfix: format.hpp - missing #include

### DIFF
--- a/format.hpp
+++ b/format.hpp
@@ -9,6 +9,7 @@
 #include <locale>
 #include <iomanip>
 #include <type_traits>
+#include <cctype>
 
 // yes I know
 #pragma GCC diagnostic ignored "-Wstrict-aliasing"


### PR DESCRIPTION
"int islower( int ch )" requires "#include <cctype>" (tested with Visual Studio 2013)