### PR TITLE
allow to not fail when recreating a table and support to drop a table

### DIFF
--- a/sweetql.hpp
+++ b/sweetql.hpp
@@ -45,6 +45,11 @@ public:
 	}
 
 	template<typename S>
+	void dropTable(bool ifExists=true) {
+		this->impl. template dropTable<S>(ifExists);
+	}
+
+	template<typename S>
 	void remove(S& s) {
 		this->impl.remove(s);
 	}

--- a/sweetql.hpp
+++ b/sweetql.hpp
@@ -40,8 +40,8 @@ public:
 	}
 
 	template<typename S>
-	void createTable() {
-		this->impl. template createTable<S>();
+	void createTable(bool ifNotExists=true) {
+		this->impl. template createTable<S>(ifNotExists);
 	}
 
 	template<typename S>

--- a/sweetqlimpl/sqliteimpl.hpp
+++ b/sweetqlimpl/sqliteimpl.hpp
@@ -277,8 +277,8 @@ public:
 				<<table.column[i].attr->getType();
 			stmtStr<<',';
 		}
-		stmtStr<<" PRIMARY KEY(";
 
+		stmtStr<<" PRIMARY KEY(";
 		bool first{true};
 		for(size_t i = 0; i < size; ++i) {
 			if(isPrimaryKey(table.column[i].attr->primaryKey)) {
@@ -287,11 +287,9 @@ public:
 				} else {
 					stmtStr<<", ";
 				}
-
 				stmtStr<<table.column[i].attrName;
 			}
 		}
-
 		stmtStr<<"));";
 
 		sqlite3_stmt* stmt;

--- a/sweetqlimpl/sqliteimpl.hpp
+++ b/sweetqlimpl/sqliteimpl.hpp
@@ -300,6 +300,18 @@ public:
 		step(stmt, stmtStr.str());
 	}
 
+	template<typename S>
+	void dropTable(bool ifExists=true) {
+		std::stringstream stmtStr;
+		stmtStr<<"DROP TABLE ";
+		if(ifExists) {
+			stmtStr<<" IF EXISTS ";
+		}
+		stmtStr<<S::table().name<<';';
+
+		sqlite3_exec(db, stmtStr.str().c_str(), NULL, NULL, NULL);
+	}
+
 private:
 	template<typename S>
 	inline static void addParameter(S& t, SqlTable<S>& tab, 

--- a/sweetqlimpl/sqliteimpl.hpp
+++ b/sweetqlimpl/sqliteimpl.hpp
@@ -263,9 +263,13 @@ public:
 	}
 
 	template<typename S>
-	void createTable() {
+	void createTable(bool ifNotExists=true) {
 		std::stringstream stmtStr;
-		stmtStr<<"CREATE TABLE "<<S::table().name<<'(';
+		stmtStr<<"CREATE TABLE ";
+		if(ifNotExists) {
+			stmtStr<<" IF NOT EXISTS ";
+		}
+		stmtStr<<S::table().name<<'(';
 		auto table(S::table());
 		const size_t size = table.column.size();
 		for(size_t i = 0; i < size; ++i) {

--- a/sweetqltest/sweetqltest.cpp
+++ b/sweetqltest/sweetqltest.cpp
@@ -203,6 +203,14 @@ PersonVec parsePersonFile(const std::string& fn) {
 	return ret;
 }
 
+UNITTEST(double_create) {
+	Sqlite3 dbImpl(":memory:");
+	SweetQL<Sqlite3> db(dbImpl);
+	db.createTable<Person>();
+	db.createTable<Person>();
+   // any good way to check existance of a table? SELECT?
+}
+
 UNITTEST(sweetqltest) {
 	/*remove("testtable2.db");
 	Sqlite3 dbImpl("testtable2.db");

--- a/sweetqltest/sweetqltest.cpp
+++ b/sweetqltest/sweetqltest.cpp
@@ -211,6 +211,12 @@ UNITTEST(double_create) {
    // any good way to check existance of a table? SELECT?
 }
 
+UNITTEST(drop_non_existing_table) {
+	Sqlite3 dbImpl(":memory:");
+	SweetQL<Sqlite3> db(dbImpl);
+	db.dropTable<Person>();
+}
+
 UNITTEST(sweetqltest) {
 	/*remove("testtable2.db");
 	Sqlite3 dbImpl("testtable2.db");


### PR DESCRIPTION
Currently when using createTable() on a non-memory db the program crashes when run the second time because we can neither drop tables nor skip to creation.
Thus, I added support for both.